### PR TITLE
Fix logic issues by introducing timestamp actions

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -19,16 +19,10 @@ export default {
     coding () {
       this.$store.commit('incrementBytes', this.$store.state.bpk);
     },
-    loop () {
+    loop (timestamp) {
       // GAME LOOP
-      this.$store.commit('bytesPerSecond');
-      this.levelManager();
+      this.$store.dispatch('update', {timestamp});
       requestAnimationFrame(this.loop);
-    },
-    levelManager () {
-      if (this.$store.getters.bytesUntilLevelUp <= 0) {
-        this.$store.commit('levelUp');
-      }
     }
   },
   created () {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -3,6 +3,16 @@ import Vuex from 'vuex'
 
 Vue.use(Vuex)
 
+const timestamps = [
+  {
+    length: 1000,
+    previous: 0,
+    action: ({commit}) => {
+      commit('bytesPerSecond');
+    }
+  }
+];
+
 export default new Vuex.Store({
   state: {
     bytes: 0,
@@ -43,6 +53,22 @@ export default new Vuex.Store({
       }
     ]
   },
+  actions: {
+    update: ({commit, getters}, payload) => {
+      let now = payload.timestamp;
+
+      timestamps.forEach(timestamp => {
+        if (now - timestamp.previous >= timestamp.length) {
+          timestamp.previous = now;
+          timestamp.action(context);
+        }
+      });
+      
+      if (getters.bytesUntilLevelUp <= 0) {
+        commit('levelUp');
+      }
+    }
+  },
   mutations: {
     incrementBytes: (state, increment) => {
       state.bytes += increment;
@@ -65,8 +91,8 @@ export default new Vuex.Store({
       state.bps = 0;
       state.upgrades.forEach(upgrade => {
         state.bps += (upgrade.bps * upgrade.quantity);
-        state.bytes += (upgrade.bps * upgrade.quantity) / 60;
-        state.totalBytes += (upgrade.bps * upgrade.quantity) / 60;
+        state.bytes += (upgrade.bps * upgrade.quantity);
+        state.totalBytes += (upgrade.bps * upgrade.quantity);
       });
     }
   },


### PR DESCRIPTION
Logic issues are created by devices that have framerates other than 60, so the logic has to rely on the current time. Fortunately, `requestAnimationFrame` passes a single parameter to our loop method, which is the current time in milliseconds. This fix takes advantage of this by implementing a `timestamps` constant which allows multiple actions to be called at varying times. The original code for bps divided by 60, which is now replaced by calling a timestamp action every 1000 milliseconds.